### PR TITLE
fix: Latest temperature may be insignificant in average computation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,7 @@ fn start_temp_loop(
 
     let mut last_temp = 0;
     let mut temps = ArrayDeque::<u8, 50, arraydeque::Wrapping>::new();
+    let mut was_long_sleep = false;
     while !cancellation_token.load(std::sync::atomic::Ordering::Relaxed) {
         let cpu_temp = read_temp_file(&mut cpu_temp_file, &mut temp_buffer)?;
         let temp = if let Some(gpu_temp_file) = &mut gpu_temp_file {
@@ -163,16 +164,18 @@ fn start_temp_loop(
         };
 
         temps.push_back(temp);
-
-        let sum_temp: u16 = temps.iter().map(|t| *t as u16).sum();
-        let mean_temp = sum_temp / (temps.len() as u16);
-        if mean_temp == last_temp {
+        if was_long_sleep {
             // Avoid messing up the mean due to the longer sleep.
             for _ in 0..9 {
                 temps.push_back(temp);
             }
+        }
 
+        let sum_temp: u16 = temps.iter().map(|t| *t as u16).sum();
+        let mean_temp = sum_temp / (temps.len() as u16);
+        if mean_temp == last_temp {
             std::thread::sleep(std::time::Duration::from_secs(1));
+            was_long_sleep = true;
         } else {
             last_temp = mean_temp;
             for fan in fans {
@@ -180,6 +183,7 @@ fn start_temp_loop(
             }
 
             std::thread::sleep(std::time::Duration::from_millis(100));
+            was_long_sleep = false;
         }
     }
 


### PR DESCRIPTION
## The issue
I noticed that t2fanrd was often slower to react to temperature spikes than the 1s poll interval suggests.

I noticed that the following happens ([here and following lines](https://github.com/GnomedDev/T2FanRD/blob/ae705d7b38181c34c12410478473b00d8374a5b8/src/main.rs#L165)):
1. append the latest temperature `temp`  to the 50 samples / 5 seconds history `temps`
2. compute the average temperature `mean_temp`
3. in case of upcoming long sleep, appropriately append extra samples of `temp` to history

At the first poll after a sudden temperature spike (say, 50°C to 90°C in <1s[^1]), the latest temp only contributes 1/50 to the average, and the integer `mean_temp` may not change. In practice, this often extends the reaction time to two intervals (up to 2s).

## Proposed change
When exiting a long sleep, append the extra samples *before* the average computation, instead of after. In other words, the latest temperature is taken into account for the *past* long sleep's duration (which is already the case for the short sleep), instead of the next's. 

> Remark 1: this does not really make the fan settings "more aggressive": in case of a temp spike that does not immediately change the average temp, the same fan spin-up that would occur at T+2, now occurs at T+1.

> Remark 2: this marginally increases how often fan speeds are set during ~idle periods, since `mean_temp` may change more often.

Let me know what you think.

[^1]: T2 Macs tend to be quite old, and like mine, may have degraded thermal paste that basically render temp hikes instantaneous.