### PR TITLE
Fix/Feat: Sensor per fan (better mac pro 7.1 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ There's four options for each fan.
 |     high_temp     |         Temperature that will trigger max fan speed         |
 |    speed_curve    |   Three options present. Will be explained in table below.  |
 | always_full_speed | if set "true", the fan will be at max speed no matter what. |
+|   sensor_group    | Three options: One(*sensor*), Max[*sensor0*, *sensor1*] or Average[*sensor0*, *sensor1*]. See table below for available sensors    |
+
+
+
+For `sensors`, there's 2 options.
+|        Key        |                            Value                            |
+|:-----------------:|:-----------------------------------------------------------:|
+|      CPU          |        Temperature average of all CPU cores                 |
+|      GPU          |        Temperature average of all GPU cards                 |
+
+
 
 For `speed_curve`, there's three options.
 |     Key     |                   Value                   |

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,20 @@
                     example = true;
                     description = "If true, the fan will be at max speed regardless of temperature.";
                   };
+
+                  sensor_group = lib.mkOption {
+                      type = lib.types.str;
+                      default = "Average[CPU, GPU]";
+                      example = "One(CPU)";
+                      description = ''
+                        Defines which sensors to use and how to aggregate them.
+                        Supported formats:
+                        - Average[Sensor1, Sensor2]
+                        - Max[Sensor1, Sensor2]
+                        - One(Sensor)
+                      '';
+                  };
+
                 };
               });
               default = {};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{io::ErrorKind, num::NonZeroUsize, path::PathBuf, str::FromStr};
+use std::{fmt::Display, io::ErrorKind, num::NonZeroUsize, path::PathBuf, str::FromStr};
 
 use nonempty::NonEmpty as NonEmptyVec;
 
@@ -38,12 +38,87 @@ impl FromStr for SpeedCurve {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct FanConfig {
     pub low_temp: u8,
     pub high_temp: u8,
     pub speed_curve: SpeedCurve,
     pub always_full_speed: bool,
+    pub sensor_group: SensorGroup,
+}
+
+#[derive(Clone, Debug)]
+pub enum SensorGroup {
+    Average(Vec<TempSensor>),
+    Max(Vec<TempSensor>),
+    One(TempSensor),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum TempSensor {
+    CPU,
+    GPU,
+}
+
+impl Display for TempSensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TempSensor::CPU => f.write_str("CPU"),
+            TempSensor::GPU => f.write_str("GPU"),
+        }
+    }
+}
+impl FromStr for SensorGroup {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Handle variants using square brackets: Max[...] and Average[...]
+        if let Some((variant_str, content)) = s.split_once('[') {
+            let sensors_str = content.strip_suffix(']').ok_or(())?;
+
+            let sensors: Vec<TempSensor> = sensors_str
+                .split(',')
+                .filter_map(|item| match item.trim() {
+                    "CPU" => Some(TempSensor::CPU),
+                    "GPU" => Some(TempSensor::GPU),
+                    _ => None,
+                })
+                .collect();
+
+            match variant_str.trim() {
+                "Max" => Ok(SensorGroup::Max(sensors)),
+                "Average" => Ok(SensorGroup::Average(sensors)),
+                _ => Err(()),
+            }
+        }
+        // Handle the variant using parentheses: One(...)
+        else if let Some((variant_str, content)) = s.split_once('(') {
+            let sensor_str = content.strip_suffix(')').ok_or(())?;
+
+            let sensor = match sensor_str.trim() {
+                "CPU" => TempSensor::CPU,
+                "GPU" => TempSensor::GPU,
+                _ => return Err(()),
+            };
+
+            match variant_str.trim() {
+                "One" => Ok(SensorGroup::One(sensor)),
+                _ => Err(()),
+            }
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl std::fmt::Display for SensorGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SensorGroup::Average(temp_sensors) => write!(f, "Average{:?}", temp_sensors),
+            SensorGroup::Max(temp_sensors) => write!(f, "Max{:?}", temp_sensors),
+            SensorGroup::One(temp_sensor) => write!(f, "One({:?})", temp_sensor),
+        }
+    }
 }
 
 impl FanConfig {
@@ -56,6 +131,7 @@ impl FanConfig {
             .set("high_temp", self.high_temp.to_string())
             .set("speed_curve", self.speed_curve.to_string())
             .set("always_full_speed", self.always_full_speed.to_string())
+            .set("sensor_group", self.sensor_group.to_string())
     }
 }
 
@@ -66,6 +142,7 @@ impl Default for FanConfig {
             high_temp: 75,
             speed_curve: SpeedCurve::Linear,
             always_full_speed: false,
+            sensor_group: SensorGroup::Max(vec![TempSensor::CPU, TempSensor::GPU]),
         }
     }
 }
@@ -86,6 +163,7 @@ impl TryFrom<&ini::Properties> for FanConfig {
             high_temp: get_value(properties, "high_temp")?,
             speed_curve: get_value(properties, "speed_curve")?,
             always_full_speed: get_value(properties, "always_full_speed")?,
+            sensor_group: get_value(properties, "sensor_group")?,
         })
     }
 }
@@ -110,7 +188,7 @@ fn generate_config_file(fan_count: NonZeroUsize) -> Result<Vec<FanConfig>> {
     let mut configs = Vec::with_capacity(fan_count.get());
     for i in 1..=fan_count.get() {
         let config = FanConfig::default();
-        configs.push(config);
+        configs.push(config.clone());
 
         let mut setter = config_file.with_section(Some(format!("Fan{i}")));
         config.write_property(&mut setter);

--- a/src/fan_controller.rs
+++ b/src/fan_controller.rs
@@ -78,10 +78,37 @@ impl FanController {
         Ok(())
     }
 
-    pub fn calc_speed(&self, temp: u8) -> u32 {
+    pub fn calc_speed(&self, cpu_temp: u8, gpu_temp: u8) -> u32 {
         if self.config.always_full_speed {
             return self.max_speed;
         }
+
+        let temp = {
+            match &self.config.sensor_group {
+                crate::config::SensorGroup::Average(temp_sensors) => {
+                    temp_sensors
+                        .iter()
+                        .map(|ts| match ts {
+                            crate::config::TempSensor::CPU => cpu_temp,
+                            crate::config::TempSensor::GPU => gpu_temp,
+                        })
+                        .sum::<u8>()
+                        / temp_sensors.len() as u8
+                }
+                crate::config::SensorGroup::Max(temp_sensors) => temp_sensors
+                    .iter()
+                    .map(|ts| match ts {
+                        crate::config::TempSensor::CPU => cpu_temp,
+                        crate::config::TempSensor::GPU => gpu_temp,
+                    })
+                    .max()
+                    .unwrap_or(85),
+                crate::config::SensorGroup::One(temp_sensor) => match temp_sensor {
+                    crate::config::TempSensor::CPU => cpu_temp,
+                    crate::config::TempSensor::GPU => gpu_temp,
+                },
+            }
+        };
 
         if temp <= self.config.low_temp {
             return self.min_speed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,8 @@ fn read_temp_file(temp_file: &mut std::fs::File, temp_buf: &mut String) -> Resul
     temp.map(|t| (t / 1000) as u8)
 }
 
-fn find_temp_file(temps: glob::Paths, temp_buf: &mut String) -> Option<std::fs::File> {
+fn find_temp_files(temps: glob::Paths, temp_buf: &mut String) -> Option<Vec<std::fs::File>> {
+    let mut temp_files = vec![];
     for temp_path_res in temps {
         let Ok(temp_path) = temp_path_res else {
             eprintln!("Unable to read glob path");
@@ -110,21 +111,24 @@ fn find_temp_file(temps: glob::Paths, temp_buf: &mut String) -> Option<std::fs::
         };
 
         if read_temp_file(&mut temp_file, temp_buf).is_ok() {
-            return Some(temp_file);
+            temp_files.push(temp_file);
         }
     }
 
-    None
+    match temp_files.is_empty() {
+        true => None,
+        false => Some(temp_files),
+    }
 }
 
-fn find_cpu_temp_file(temp_buf: &mut String) -> Result<std::fs::File> {
-    let temps = glob::glob("/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp1_input")?;
-    find_temp_file(temps, temp_buf).ok_or(Error::NoCpu)
+fn find_cpu_temp_file(temp_buf: &mut String) -> Result<Vec<std::fs::File>> {
+    let temps = glob::glob("/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp*_input")?;
+    find_temp_files(temps, temp_buf).ok_or(Error::NoCpu)
 }
 
-fn find_gpu_temp_file(temp_buf: &mut String) -> Result<Option<std::fs::File>> {
-    let temps = glob::glob("/sys/class/drm/card0/device/hwmon/hwmon*/temp1_input")?;
-    Ok(find_temp_file(temps, temp_buf))
+fn find_gpu_temp_file(temp_buf: &mut String) -> Result<Option<Vec<std::fs::File>>> {
+    let temps = glob::glob("/sys/class/drm/card*/device/hwmon/hwmon*/temp*_input")?;
+    Ok(find_temp_files(temps, temp_buf))
 }
 
 fn main() -> ExitCode {
@@ -139,48 +143,66 @@ fn main() -> ExitCode {
 
 fn start_temp_loop(
     mut temp_buffer: String,
-    mut cpu_temp_file: std::fs::File,
-    mut gpu_temp_file: Option<std::fs::File>,
+    mut cpu_temp_files: Vec<std::fs::File>,
+    mut gpu_temp_files: Option<Vec<std::fs::File>>,
     fans: &NonEmptyVec<FanController>,
 ) -> Result<()> {
     let cancellation_token = Arc::new(AtomicBool::new(false));
     signal_hook::flag::register(SIGINT, cancellation_token.clone()).map_err(Error::Signal)?;
     signal_hook::flag::register(SIGTERM, cancellation_token.clone()).map_err(Error::Signal)?;
 
-    let mut last_temp = 0;
-    let mut temps = ArrayDeque::<u8, 50, arraydeque::Wrapping>::new();
+    //let mut cpu_last_temp = 0;
+    //let mut gpu_last_temp = 0;
+    let mut cpu_temps = ArrayDeque::<u8, 50, arraydeque::Wrapping>::new();
+    let mut gpu_temps = ArrayDeque::<u8, 50, arraydeque::Wrapping>::new();
     while !cancellation_token.load(std::sync::atomic::Ordering::Relaxed) {
-        let cpu_temp = read_temp_file(&mut cpu_temp_file, &mut temp_buffer)?;
-        let temp = if let Some(gpu_temp_file) = &mut gpu_temp_file {
-            let gpu_temp = read_temp_file(gpu_temp_file, &mut temp_buffer)?;
-            if gpu_temp > cpu_temp {
-                gpu_temp
-            } else {
-                cpu_temp
+        let cpu_temp = {
+            let mut core_temps = vec![];
+            for mut cpu_temp_file in &mut cpu_temp_files {
+                let core_temp = read_temp_file(&mut cpu_temp_file, &mut temp_buffer)?;
+                core_temps.push(core_temp);
             }
+            *core_temps.iter().max().unwrap_or(&85)
+        };
+
+        let gpu_temp = if let Some(gpu_temp_files) = &mut gpu_temp_files {
+            let gpu_temp = {
+                let mut cards_temps = vec![];
+                for mut gpu_temp_file in gpu_temp_files {
+                    let card_temp = read_temp_file(&mut gpu_temp_file, &mut temp_buffer)?;
+                    cards_temps.push(card_temp);
+                }
+                *cards_temps.iter().max().unwrap_or(&85)
+            };
+            gpu_temp
         } else {
             cpu_temp
         };
 
-        temps.push_back(temp);
+        cpu_temps.push_back(cpu_temp);
+        gpu_temps.push_back(gpu_temp);
 
-        let sum_temp: u16 = temps.iter().map(|t| *t as u16).sum();
-        let mean_temp = sum_temp / (temps.len() as u16);
-        if mean_temp == last_temp {
+        let gpu_sum_temp: u16 = gpu_temps.iter().map(|t| *t as u16).sum();
+        let gpu_mean_temp = gpu_sum_temp / (gpu_temps.len() as u16);
+
+        let cpu_sum_temp: u16 = cpu_temps.iter().map(|t| *t as u16).sum();
+        let cpu_mean_temp = cpu_sum_temp / (cpu_temps.len() as u16);
+
+        if cpu_mean_temp == cpu_sum_temp && gpu_mean_temp == gpu_sum_temp {
             // Avoid messing up the mean due to the longer sleep.
             for _ in 0..9 {
-                temps.push_back(temp);
+                cpu_temps.push_back(cpu_temp);
+                gpu_temps.push_back(gpu_temp);
             }
-
             std::thread::sleep(std::time::Duration::from_secs(1));
-        } else {
-            last_temp = mean_temp;
-            for fan in fans {
-                fan.set_speed(fan.calc_speed(mean_temp as u8))?;
-            }
-
-            std::thread::sleep(std::time::Duration::from_millis(100));
         }
+
+        //cpu_last_temp = cpu_mean_temp;
+
+        for fan in fans {
+            fan.set_speed(fan.calc_speed(cpu_mean_temp as u8, gpu_mean_temp as u8))?;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,8 @@ fn start_temp_loop(
     signal_hook::flag::register(SIGINT, cancellation_token.clone()).map_err(Error::Signal)?;
     signal_hook::flag::register(SIGTERM, cancellation_token.clone()).map_err(Error::Signal)?;
 
-    //let mut cpu_last_temp = 0;
-    //let mut gpu_last_temp = 0;
+    let mut cpu_last_temp = 0;
+    let mut gpu_last_temp = 0;
     let mut cpu_temps = ArrayDeque::<u8, 50, arraydeque::Wrapping>::new();
     let mut gpu_temps = ArrayDeque::<u8, 50, arraydeque::Wrapping>::new();
     while !cancellation_token.load(std::sync::atomic::Ordering::Relaxed) {
@@ -188,7 +188,7 @@ fn start_temp_loop(
         let cpu_sum_temp: u16 = cpu_temps.iter().map(|t| *t as u16).sum();
         let cpu_mean_temp = cpu_sum_temp / (cpu_temps.len() as u16);
 
-        if cpu_mean_temp == cpu_sum_temp && gpu_mean_temp == gpu_sum_temp {
+        if cpu_mean_temp == cpu_last_temp && gpu_mean_temp == gpu_last_temp {
             // Avoid messing up the mean due to the longer sleep.
             for _ in 0..9 {
                 cpu_temps.push_back(cpu_temp);
@@ -197,7 +197,8 @@ fn start_temp_loop(
             std::thread::sleep(std::time::Duration::from_secs(1));
         }
 
-        //cpu_last_temp = cpu_mean_temp;
+        cpu_last_temp = cpu_mean_temp;
+        gpu_last_temp = gpu_mean_temp;
 
         for fan in fans {
             fan.set_speed(fan.calc_speed(cpu_mean_temp as u8, gpu_mean_temp as u8))?;


### PR DESCRIPTION
# the issue

## GPU temp sensor on mac pro 7.1
Using T2FanRD on mac pro 7.1 can't read GPU temps (my GPU appears on card1 rather than card0)

## Proposed change
- Changed the glob path to return the temps files for all GPU using '.../card*/...' instead of '.../card1/...' then use the max temp
- Changed the glob path for CPU temps to query all CPU core then use the max temp

------

## Mac pro 7.1 GPU fan speed
Bottom fan can't be controlled by the GPU temp alone

## Proposed change
Added one option to the configuration file to select a specific sensor or set of sensor to control each fan
by setting the option 'sensor_group'.

|        SensorGroup        |                            Value                            |
|:-----------------:|:-----------------------------------------------------------:|
|   One(*sensor*)    | Use only the selected sensor temperature  |
|   Max[*sensor0*, *sensor1*]    | Use max temperature between both sensors |
|   Average[*sensor0*, *sensor1*]    | Average temperature of both sensors |



For `sensors`, there's 2 options.
|        Sensor        |                            Value                            |
|:-----------------:|:-----------------------------------------------------------:|
|      CPU          |        Temperature average of all CPU cores                 |
|      GPU          |        Temperature average of all GPU cards                 |

ie for mac pro 7.1 bottom front fan: 
``` 
[Fan2]
low_temp=55
high_temp=75
speed_curve=linear
always_full_speed=false
sensor_group=One(GPU)
```