### PR TITLE
Re-assert manual fan control after resume from sleep

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,8 @@ pub enum Error {
     FanOpen(#[source] std::io::Error),
     #[error("Cannot write to fan controller")]
     FanWrite(#[source] std::io::Error),
+    #[error("Cannot read from fan controller")]
+    FanRead(#[source] std::io::Error),
 
     #[error("Cannot setup shutdown signals")]
     Signal(#[source] std::io::Error),

--- a/src/fan_controller.rs
+++ b/src/fan_controller.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{IsTerminal, Write},
+    io::{IsTerminal, Read, Seek, Write},
     path::PathBuf,
 };
 
@@ -38,14 +38,17 @@ impl FanController {
             .parse()
             .map_err(Error::MaxSpeedParse)?;
 
-        let mut open_options = std::fs::OpenOptions::new();
-        open_options.write(true).truncate(true);
-
-        let manual_file = open_options
+        // The manual flag is also read back every loop iteration, as the SMC
+        // resets it to 0 on resume from sleep.
+        let manual_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
             .open(join_suffix(path.clone(), "_manual"))
             .map_err(Error::FanOpen)?;
 
-        let output_file = open_options
+        let output_file = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
             .open(join_suffix(path, "_output"))
             .map_err(Error::FanOpen)?;
 
@@ -65,6 +68,19 @@ impl FanController {
         (&self.manual_file)
             .write_all(if enabled { b"1" } else { b"0" })
             .map_err(Error::FanWrite)
+    }
+
+    /// Reads back whether the fan is still under manual (daemon) control.
+    ///
+    /// The T2 SMC silently flips `fan*_manual` back to `0` after the system
+    /// resumes from sleep, at which point every `fan*_output` write is ignored
+    /// and the firmware runs the fans at full speed.
+    pub fn is_manual(&self) -> Result<bool> {
+        let mut buf = [0u8; 1];
+        let mut manual_file = &self.manual_file;
+        manual_file.rewind().map_err(Error::FanRead)?;
+        let read = manual_file.read(&mut buf).map_err(Error::FanRead)?;
+        Ok(read == 1 && buf[0] == b'1')
     }
 
     pub fn set_speed(&self, mut speed: u32) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,16 @@ fn start_temp_loop(
     let mut temps = ArrayDeque::<u8, 50, arraydeque::Wrapping>::new();
     let mut was_long_sleep = false;
     while !cancellation_token.load(std::sync::atomic::Ordering::Relaxed) {
+        // The SMC drops manual mode on resume from sleep; if that happened,
+        // take control back and make sure the speed is re-applied below.
+        for fan in fans {
+            if !fan.is_manual()? {
+                eprintln!("Fan manual mode was reset (resume from sleep?), re-enabling");
+                fan.set_manual(true)?;
+                last_temp = 0;
+            }
+        }
+
         let cpu_temp = read_temp_file(&mut cpu_temp_file, &mut temp_buffer)?;
         let temp = if let Some(gpu_temp_file) = &mut gpu_temp_file {
             let gpu_temp = read_temp_file(gpu_temp_file, &mut temp_buffer)?;


### PR DESCRIPTION
## Problem

After the machine resumes from suspend, the T2 SMC flips `fan*_manual` back to `0`. The daemon only writes the manual flag once at startup, so from that point on every `fan*_output` write is silently ignored and the firmware runs both fans at full speed no matter the temperature.

Nothing in the daemon fails or logs, which makes this hard to spot. Observed on a MacBook Pro 16,1 (Arch, `linux-t2`), where after a resume `sensors` showed 5616 / 5200 RPM with the CPU package at ~63 °C, `fan1_manual=0`, and `t2fanrd` still running happily with `fan1_output=5616`.

## Fix

Open `fan*_manual` read+write and read it back on every loop iteration. If it was reset, write `1` again, log a line, and force the current speed to be re-applied on that tick (by clearing `last_temp`). Reading a sysfs attribute every 100 ms / 1 s is cheap.

Shutdown behaviour is unchanged: SIGTERM still hands control back to the firmware (`manual=0`) and removes the pid file.

## Testing

- `cargo fmt --check`, `cargo clippy --release --all-targets` (pedantic) clean.
- Ran the new build as root, then `echo 0 > fan1_manual` / `fan2_manual` to mimic a resume: both flags were back at `1` on the next tick, the log showed `Fan manual mode was reset (resume from sleep?), re-enabling`, and `fan1_output` was rewritten to the computed speed.
- SIGTERM: `manual` returned to `0`, pid file removed.

Until now the workaround was a `systemd` sleep hook that restarts the service on `post`; with this change that is no longer needed.
